### PR TITLE
Check if index exists if not I init metadata map.

### DIFF
--- a/bin/setup_elastic.py
+++ b/bin/setup_elastic.py
@@ -11,9 +11,15 @@ class ElasticInitializer(object):
     def initialize(self):
         config = self.read_config()
         connection = Connection(config["connectionString"],
-                config.get("accessKey"), config.get("secretKey"), config.get("region"))
-        connection.indices.create(index=connection.es_index, ignore=400)
-        Metadata.init(using=connection, index=connection.es_index)
+                                config.get("accessKey"),
+                                config.get("secretKey"),
+                                config.get("region"))
+
+        index_exists = connection.indices.exists(index=connection.es_index)
+
+        if not index_exists:
+            Metadata.init(using=connection, index=connection.es_index)
+
         connection.indices.refresh(index=connection.es_index)
 
     def read_config(self):


### PR DESCRIPTION
Amazon doesn't allow you to close indices. This will work for our purposes. We may have to adjust in the future depending on if we change the way we store metadata. I didn't want to spend more time then I had to on it. 