### PR TITLE
forcing new artifact path every time bulk update runs

### DIFF
--- a/pyshelf/bucket_update/artifact_metadata_updater.py
+++ b/pyshelf/bucket_update/artifact_metadata_updater.py
@@ -28,8 +28,7 @@ class ArtifactMetadataUpdater(object):
 
         metadata = portal.load(self.identity.cloud_metadata)
 
-        if initializer.needs_update(metadata):
-            metadata = initializer.update(self.identity, metadata)
-            portal.update(self.identity.cloud_metadata, metadata)
+        metadata = initializer.update(self.identity, metadata)
+        portal.update(self.identity.cloud_metadata, metadata)
 
         self._metadata = metadata

--- a/tests/bucket_update/artifact_metadata_updater_test.py
+++ b/tests/bucket_update/artifact_metadata_updater_test.py
@@ -6,7 +6,13 @@ from pyshelf.metadata.keys import Keys
 
 
 class ArtifactMetadataUpdaterTest(TestBase):
-    def test_run_initialization_needed(self):
+    def test_run_initialization_always(self):
+        """
+            Important that whenever this runs it always
+            reinitializes.  Specifically this is because
+            somebody may change the referenceName.  In that
+            case it must be updated to be the new artifactPath
+        """
         path = "/test/artifact/my/fake/path"
         identity = ResourceIdentity(path)
         metadata = {
@@ -14,8 +20,14 @@ class ArtifactMetadataUpdaterTest(TestBase):
                 "name": "lol",
                 "value": "whatever",
                 "immutable": False,
+            },
+            Keys.PATH: {
+                "name": Keys.PATH,
+                "value": "/testing-api-bucket/artifact/my/fake/path",
+                "immutable": True
             }
         }
+
         builder = MetadataBuilder(metadata)
 
         # Specifically setting it instead of
@@ -44,5 +56,12 @@ class ArtifactMetadataUpdaterTest(TestBase):
         for key in expected_keys:
             if key not in new_metadata:
                 self.fail("Key {0} was not initialized".format(key))
+
+        expected_artifact_path = {
+            "name": Keys.PATH,
+            "value": path,
+            "immutable": True
+        }
+        self.assertEqual(expected_artifact_path, new_metadata["artifactPath"])
 
         self.assertEqual(updater.metadata, new_metadata)


### PR DESCRIPTION
And actually new metadata every time.  this will make bulk update
take longer but I am more ok with that.

Note this will NOT happen for a regular metadata update.