### PR TITLE
fixing chunk so we don't get duplicates

### DIFF
--- a/pyshelf/bucket_update/search_updater.py
+++ b/pyshelf/bucket_update/search_updater.py
@@ -87,10 +87,5 @@ class SearchUpdater(object):
             A generate that will (with each yield) return the next
             chunk of artifact paths that should be processed
         """
-        # Defaulting index is important here if path_list is
-        # empty
-        index = 0
         for index in range(0, len(path_list), self.chunk_size):
             yield path_list[index: index + self.chunk_size]
-
-        yield path_list[index:]

--- a/tests/bucket_update/search_updater_test.py
+++ b/tests/bucket_update/search_updater_test.py
@@ -65,3 +65,47 @@ class SearchUpdaterTest(TestBase):
         logger.info = Mock()
         updater = self.container.search_updater
         updater.run()
+
+    def run_chunk(self, chunk_size, path_list, expected_list):
+        search_updater = self.container.search_updater
+        search_updater.chunk_size = chunk_size
+        actual_list = []
+        for chunk in search_updater._chunk(path_list):
+            actual_list.append(chunk)
+
+        self.assertEqual(expected_list, actual_list)
+
+    def test_less_than_chunk(self):
+        path_list = [
+            "abc123",
+            "abc124",
+        ]
+
+        expected_list = [
+            [
+                "abc123",
+                "abc124"
+            ]
+        ]
+
+        self.run_chunk(3, path_list, expected_list)
+
+    def test_more_than_chunk(self):
+        path_list = [1, 2, 3, 4]
+
+        expected_list = [
+            [1, 2, 3],
+            [4]
+        ]
+
+        self.run_chunk(3, path_list, expected_list)
+
+    def test_exactly_chunk(self):
+        path_list = [1, 2, 3, 4, 5, 6]
+
+        expected_list = [
+            [1, 2, 3],
+            [4, 5, 6]
+        ]
+
+        self.run_chunk(3, path_list, expected_list)


### PR DESCRIPTION
I was trying to code for a solution I didn't need to.  Because python
is "cool like that" if I try to slice an array and it is not large
enough, it will just give me back what it has.  For example

>> a = [1, 2]
>> a[0:3]
[1, 2]