### PR TITLE
Fixing sort function to prevent it blowing up when the field is missing

### DIFF
--- a/changelog
+++ b/changelog
@@ -16,3 +16,7 @@ and default to a more reasonable number.
 v6 - Improve metadata validation and error messages. Default immutable on
 metadata properties if it is not there. Ignore additional properties on
 metadata.
+v6.1 - Sort blows up if metadata property that doesn't exist is sorted on.
+This was fixed in this release. Now it is sorted as None. Which results in
+results without the property that is being sorted on to be first in ASC sorts
+and last in DESC sorts.

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -27,10 +27,10 @@ Sort criteria:
 * The sort criteria must start with the field name.
 * The default sort type is ascending. If multiple sort types are given the last is used.
 * With multi-sorts the first sort takes precedence.
-* If a property that does not exist is sorted on it is treated as None.
-    * Ex. if you sort on buildNumber and a result returned does not have a buildNumber
-    metadata property, this artifact will be returned first on an ASC search and last on a
-    DESC search.
+* If a property that does not exist is sorted on it is treated as `None`.
+    * Ex. if you sort on `buildNumber` and a result returned does not have a `buildNumber`
+    metadata property, this artifact will be returned first on an `ASC` search and last on a
+    `DESC` search.
 
 Limit:
 ------

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -27,6 +27,10 @@ Sort criteria:
 * The sort criteria must start with the field name.
 * The default sort type is ascending. If multiple sort types are given the last is used.
 * With multi-sorts the first sort takes precedence.
+* If a property that does not exist is sorted on it is treated as None.
+    * Ex. if you sort on buildNumber and a result returned does not have a buildNumber
+    metadata property, this artifact will be returned first on an ASC search and last on a
+    DESC search.
 
 Limit:
 ------

--- a/pyshelf/search/container.py
+++ b/pyshelf/search/container.py
@@ -1,6 +1,7 @@
 from pyshelf.search.update_manager import UpdateManager
 from pyshelf.search.manager import Manager
 from pyshelf.search.connection import Connection
+from pyshelf.search.sorter import Sorter
 
 
 class Container(object):
@@ -12,9 +13,14 @@ class Container(object):
         self._update_manager = None
         self._manager = None
         self._connection = None
+        self._sorter = None
 
     @property
     def update_manager(self):
+        """
+            Returns:
+                pyshelf.search.update_manager.UpdateManager
+        """
         if not self._update_manager:
             self._update_manager = UpdateManager(self.logger, self.connection)
 
@@ -22,13 +28,32 @@ class Container(object):
 
     @property
     def manager(self):
+        """
+            Returns:
+                pyshelf.search.manager.Manager
+        """
         if not self._manager:
             self._manager = Manager(self)
 
         return self._manager
 
     @property
+    def sorter(self):
+        """
+            Returns:
+                pyshelf.search.sorter.Sorter
+        """
+        if not self._sorter:
+            self._sorter = Sorter()
+
+        return self._sorter
+
+    @property
     def connection(self):
+        """
+            Returns:
+                pyshelf.search.connection.Connection
+        """
         if not self._connection:
             self._connection = Connection(
                 self.config["connectionString"],

--- a/pyshelf/search/formatter.py
+++ b/pyshelf/search/formatter.py
@@ -1,6 +1,4 @@
 from distutils.version import LooseVersion
-from pyshelf.search.sort_type import SortType
-from pyshelf.search.sort_flag import SortFlag
 from pyshelf.search.type import Type as SearchType
 
 
@@ -17,8 +15,6 @@ class Formatter(object):
                                 all fields will be returned.
         """
         self.search_criteria = criteria.get("search")
-        # Sort criteria must be reversed to ensure first sort criteria takes precedence
-        self.sort_criteria = reversed(criteria.get("sort", []))
         self.search_results = search_results
         self.key_list = key_list
         self.version_search = self._get_version_search()
@@ -33,12 +29,15 @@ class Formatter(object):
         result_list = self._normalize_result_list(self.search_results.hits)
         filtered_results = self._filter_metadata(result_list)
         filtered_results = self._filter_metadata_properties(filtered_results)
-        return self._sort_results(filtered_results)
+        return filtered_results
 
     def _get_version_search(self):
         """
             Determines if a version search has been requested and stores the
             field and value if so for future result filtering.
+
+            Returns:
+                dict
         """
         version_search = {}
 
@@ -131,35 +130,6 @@ class Formatter(object):
             return filtered_list
 
         return filtered_results
-
-    def _sort_results(self, formatted_results):
-        """
-            Sorts results based on sort criteria.
-
-            Args:
-                formatted_results(List[dict]): Result set as formatted by self._filter_metadata.
-
-            Returns:
-                List[dict]: sorted results.
-        """
-        # Function that sorts results. Returns None if field being sorted on does not exist.
-        # This causes results without the field that is being sorted by to be at the end
-        # of the sort results on a DESC sort and beginning of ASC sort.
-        # Used def as opposed to lambda because of my linter complained about assigning a lambda.
-        def sort(result):
-            return result.get(criteria["field"], {}).get("value")
-
-        for criteria in self.sort_criteria:
-            reverse = False
-            if SortType.DESC == criteria["sort_type"]:
-                reverse = True
-
-            if criteria.get("flag_list") and SortFlag.VERSION in criteria.get("flag_list"):
-                formatted_results.sort(key=lambda k: LooseVersion(sort(k)), reverse=reverse)
-            else:
-                formatted_results.sort(key=sort, reverse=reverse)
-
-        return formatted_results
 
     def _normalize_result_list(self, result_list):
         """

--- a/pyshelf/search/formatter.py
+++ b/pyshelf/search/formatter.py
@@ -142,17 +142,22 @@ class Formatter(object):
             Returns:
                 List[dict]: sorted results.
         """
+        # Function that sorts results. Returns None if field being sorted on does not exist.
+        # This causes results without the field that is being sorted by to be at the end
+        # of the sort results on a DESC sort and beginning of ASC sort.
+        # Used def as opposed to lambda because of my linter complained about assigning a lambda.
+        def sort(result):
+            return result.get(criteria["field"], {}).get("value")
+
         for criteria in self.sort_criteria:
             reverse = False
             if SortType.DESC == criteria["sort_type"]:
                 reverse = True
 
-            val = lambda k: k[criteria["field"]]["value"]
-
             if criteria.get("flag_list") and SortFlag.VERSION in criteria.get("flag_list"):
-                formatted_results.sort(key=lambda k: LooseVersion(val(k)), reverse=reverse)
+                formatted_results.sort(key=lambda k: LooseVersion(sort(k)), reverse=reverse)
             else:
-                formatted_results.sort(key=val, reverse=reverse)
+                formatted_results.sort(key=sort, reverse=reverse)
 
         return formatted_results
 

--- a/pyshelf/search/manager.py
+++ b/pyshelf/search/manager.py
@@ -16,7 +16,7 @@ class Manager(object):
             Builds ElasticSearch query.
 
             Args:
-                criteria(schemas/search-layer-criteriai.json): Criteria to use to initiate search.
+                criteria(schemas/search-layer-criteria.json): Criteria to use to initiate search.
                 key_list(list): List of keys to receive back from a search.
 
             Returns:

--- a/pyshelf/search/sorter.py
+++ b/pyshelf/search/sorter.py
@@ -10,6 +10,7 @@ class Sorter(object):
 
             Args:
                 data(List[dict]): Data to sort using given sort criteria.
+                sort_criteria(schemas/sort-criteria.json): sort criteria.
 
             Returns:
                 List[dict]: sorted results.

--- a/pyshelf/search/sorter.py
+++ b/pyshelf/search/sorter.py
@@ -1,0 +1,39 @@
+from distutils.version import LooseVersion
+from pyshelf.search.sort_type import SortType
+from pyshelf.search.sort_flag import SortFlag
+
+
+class Sorter(object):
+    def sort(self, data, sort_criteria):
+        """
+            Sorts results based on sort criteria.
+
+            Args:
+                data(List[dict]): Data to sort using given sort criteria.
+
+            Returns:
+                List[dict]: sorted results.
+        """
+        # Function that sorts results. Returns None if field being sorted on does not exist.
+        # This causes results without the field that is being sorted by to be at the end
+        # of the sort results on a DESC sort and beginning of ASC sort.
+        # Used def as opposed to lambda because of my linter complained about assigning a lambda.
+        def sort_result(result):
+            return result.get(criteria["field"], {}).get("value")
+
+        # Criteria for sorting is reversed so the order is respected.
+        # Basically the method we are using to search must started with the last
+        # sort first so the first sort take precedence.
+        sort_criteria.reverse()
+
+        for criteria in sort_criteria:
+            reverse = False
+            if SortType.DESC == criteria["sort_type"]:
+                reverse = True
+
+            if criteria.get("flag_list") and SortFlag.VERSION in criteria.get("flag_list"):
+                data.sort(key=lambda k: LooseVersion(sort_result(k)), reverse=reverse)
+            else:
+                data.sort(key=sort_result, reverse=reverse)
+
+        return data

--- a/pyshelf/search_portal.py
+++ b/pyshelf/search_portal.py
@@ -10,6 +10,10 @@ class SearchPortal(object):
         This class is the link between the request/view and the search layer.
     """
     def __init__(self, container):
+        """
+            Args:
+                container(pyshelf.container.Container)
+        """
         self.container = container
         self.search_manager = self.container.search.manager
         self.search_parser = self.container.search_parser
@@ -38,7 +42,12 @@ class SearchPortal(object):
         criteria["search"].append(search_path)
 
         formatted_criteria = self.search_parser.from_request(criteria)
+        sort_criteria = formatted_criteria.get("sort", [])
         results = self.search_manager.search(formatted_criteria)
+
+        if sort_criteria:
+            results = self.container.search.sorter.sort(results, sort_criteria)
+
         artifact_list = self._list_artifacts(results, criteria.get("limit"))
         self.link_manager.assign_listing(artifact_list)
 

--- a/tests/routes/search_test.py
+++ b/tests/routes/search_test.py
@@ -90,41 +90,25 @@ class SearchTest(FunctionalTestBase):
             }) \
             .post({}, headers=self.auth)
 
-    def test_sort_no_metadata(self):
-        # Adding metadata tag THINGS to test artifact to ensure it comes first
-        # on DESC search.
-        self.route_tester \
-            .metadata_item() \
-            .route_params(bucket_name="test", path="test", item="THINGS") \
-            .expect(201) \
-            .put(data={"value": "just stuff"}, headers=self.auth)
-        self.assert_metadata_matches("/test/artifact/test/_meta")
-
-        link_list = [
-            "</test/artifact/test>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/blah>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/a>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/zzzz>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/dir/dir2/Test>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/this/that/other>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/thing>; rel=\"item\"; title=\"artifact\"",
-            "</test/artifact/dir/dir2/dir3/nest-test>; rel=\"item\"; title=\"artifact\""
-        ]
-
-        # test artifact is first result
+    def test_sort_metadata_property_does_not_exist(self):
+        # Ensuring we don't blow up on a sort like this.
+        # This was a bug cataloged AGI-1346 and changelog release v6.1
         self.route_tester \
             .search() \
             .route_params(bucket_name="test", path="") \
-            .expect(204, headers={"Link": link_list}) \
-            .post({"sort": "THINGS, DESC"}, headers=self.auth)
-
-        # test artifact is last result
-        link_list.append(link_list.pop(0))
-        self.route_tester \
-            .search() \
-            .route_params(bucket_name="test", path="") \
-            .expect(204, headers={"Link": link_list}) \
-            .post({"sort": "THINGS, ASC"}, headers=self.auth)
+            .expect(204, headers={
+                "Link": [
+                    "</test/artifact/blah>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/a>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/zzzz>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/dir/dir2/Test>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/this/that/other>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/thing>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/test>; rel=\"item\"; title=\"artifact\"",
+                    "</test/artifact/dir/dir2/dir3/nest-test>; rel=\"item\"; title=\"artifact\""
+                ]
+            }) \
+            .post({"sort": "THINGS"}, headers=self.auth)
 
     def test_just_sort(self):
         self.route_tester \

--- a/tests/routes/search_test.py
+++ b/tests/routes/search_test.py
@@ -90,6 +90,13 @@ class SearchTest(FunctionalTestBase):
             }) \
             .post({}, headers=self.auth)
 
+    def test_sort_no_metadata(self):
+        self.route_tester \
+            .search() \
+            .route_params(bucket_name="test", path="") \
+            .expect(204) \
+            .post({"sort": "THINGS"}, headers=self.auth)
+
     def test_just_sort(self):
         self.route_tester \
             .search() \

--- a/tests/routes/search_test.py
+++ b/tests/routes/search_test.py
@@ -92,7 +92,8 @@ class SearchTest(FunctionalTestBase):
 
     def test_sort_metadata_property_does_not_exist(self):
         # Ensuring we don't blow up on a sort like this.
-        # This was a bug cataloged AGI-1346 and changelog release v6.1
+        # This was a bug cataloged https://github.com/kyle-long/pyshelf/issues/61
+        # and changelog release v6.1
         self.route_tester \
             .search() \
             .route_params(bucket_name="test", path="") \

--- a/tests/routes/search_test.py
+++ b/tests/routes/search_test.py
@@ -91,11 +91,40 @@ class SearchTest(FunctionalTestBase):
             .post({}, headers=self.auth)
 
     def test_sort_no_metadata(self):
+        # Adding metadata tag THINGS to test artifact to ensure it comes first
+        # on DESC search.
+        self.route_tester \
+            .metadata_item() \
+            .route_params(bucket_name="test", path="test", item="THINGS") \
+            .expect(201) \
+            .put(data={"value": "just stuff"}, headers=self.auth)
+        self.assert_metadata_matches("/test/artifact/test/_meta")
+
+        link_list = [
+            "</test/artifact/test>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/blah>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/a>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/zzzz>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/dir/dir2/Test>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/this/that/other>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/thing>; rel=\"item\"; title=\"artifact\"",
+            "</test/artifact/dir/dir2/dir3/nest-test>; rel=\"item\"; title=\"artifact\""
+        ]
+
+        # test artifact is first result
         self.route_tester \
             .search() \
             .route_params(bucket_name="test", path="") \
-            .expect(204) \
-            .post({"sort": "THINGS"}, headers=self.auth)
+            .expect(204, headers={"Link": link_list}) \
+            .post({"sort": "THINGS, DESC"}, headers=self.auth)
+
+        # test artifact is last result
+        link_list.append(link_list.pop(0))
+        self.route_tester \
+            .search() \
+            .route_params(bucket_name="test", path="") \
+            .expect(204, headers={"Link": link_list}) \
+            .post({"sort": "THINGS, ASC"}, headers=self.auth)
 
     def test_just_sort(self):
         self.route_tester \

--- a/tests/search/manager_test.py
+++ b/tests/search/manager_test.py
@@ -1,8 +1,6 @@
 from tests.unit_test_base import UnitTestBase
 from tests.search.test_wrapper import TestWrapper as SearchTestWrapper
 from pyshelf.search.type import Type as SearchType
-from pyshelf.search.sort_type import SortType
-from pyshelf.search.sort_flag import SortFlag
 from pyshelf.search.connection import Connection
 import tests.metadata_utils as utils
 
@@ -41,7 +39,7 @@ class ManagerTest(UnitTestBase):
             ]
         })
         expected = [utils.get_meta()]
-        self.assertEqual(expected, results)
+        self.asserts.json_equals(expected, results)
 
     def test_no_match(self):
         results = self.manager.search({
@@ -53,9 +51,9 @@ class ManagerTest(UnitTestBase):
                 }
             ]
         })
-        self.assertEqual([], results)
+        self.asserts.json_equals([], results)
 
-    def test_tilde_search_and_sort(self):
+    def test_tilde_search(self):
         results = self.manager.search({
             "search": [
                 {
@@ -63,24 +61,14 @@ class ManagerTest(UnitTestBase):
                     "search_type": SearchType.VERSION,
                     "value": "1.1"
                 }
-            ],
-            "sort": [
-                {
-                    "field": "version",
-                    "sort_type": SortType.ASC,
-                    "flag_list": [
-                        SortFlag.VERSION
-                    ]
-                },
             ]
         })
-        self.maxDiff = None
         expected = [
-            utils.get_meta("other", "/this/that/other", "1.1"),
-            utils.get_meta("thing", "/thing", "1.2"),
             utils.get_meta("a", "/a", "1.19"),
             utils.get_meta("blah", "/blah", "1.19"),
-            utils.get_meta("zzzz", "/zzzz", "1.19")
+            utils.get_meta("other", "/this/that/other", "1.1"),
+            utils.get_meta("thing", "/thing", "1.2"),
+            utils.get_meta("zzzz", "/zzzz", "1.19"),
         ]
         self.asserts.json_equals(expected, results)
 
@@ -101,7 +89,7 @@ class ManagerTest(UnitTestBase):
                 "immutable": True
             }
         }
-        self.assertEqual(expected, results[0])
+        self.asserts.json_equals(expected, results[0])
 
     def test_dumb_tilde_search(self):
         results = self.manager.search({
@@ -111,52 +99,15 @@ class ManagerTest(UnitTestBase):
                     "search_type": SearchType.VERSION,
                     "value": "test"
                 }
-            ],
-            "sort": [
-                {
-                    "field": "artifactName",
-                    "sort_type": SortType.DESC
-                }
             ]
         })
         expected = [
-            utils.get_meta("zzzz", "/zzzz", "1.19"),
+            utils.get_meta(),
             utils.get_meta("thing", "/thing", "1.2"),
-            utils.get_meta()
-        ]
-
-        self.assertEqual(expected, results)
-
-    def test_sorted_desc_and_asc(self):
-        results = self.manager.search({
-            "search": [
-                {
-                    "field": "version",
-                    "search_type": SearchType.VERSION,
-                    "value": "1.2"
-                }
-            ],
-            "sort": [
-                {
-                    "field": "version",
-                    "sort_type": SortType.DESC,
-                    "flag_list": [
-                        SortFlag.VERSION
-                    ]
-                },
-                {
-                    "field": "artifactName",
-                    "sort_type": SortType.ASC
-                }
-            ]
-        })
-        expected = [
-            utils.get_meta("a", "/a", "1.19"),
-            utils.get_meta("blah", "/blah", "1.19"),
             utils.get_meta("zzzz", "/zzzz", "1.19"),
-            utils.get_meta("thing", "/thing", "1.2")
         ]
-        self.assertEqual(expected, results)
+
+        self.asserts.json_equals(expected, results)
 
     def test_more_then_ten_results(self):
         data = []

--- a/tests/search/manager_test.py
+++ b/tests/search/manager_test.py
@@ -72,6 +72,23 @@ class ManagerTest(UnitTestBase):
         ]
         self.asserts.json_equals(expected, results)
 
+    def test_minor_version_search(self):
+        results = self.manager.search({
+            "search": [
+                {
+                    "field": "version",
+                    "search_type": SearchType.VERSION,
+                    "value": "1.19"
+                }
+            ]
+        })
+        expected = [
+            utils.get_meta("a", "/a", "1.19"),
+            utils.get_meta("blah", "/blah", "1.19"),
+            utils.get_meta("zzzz", "/zzzz", "1.19"),
+        ]
+        self.asserts.json_equals(expected, results)
+
     def test_select_fields(self):
         results = self.manager.search({
             "search": [

--- a/tests/search/sorter_test.py
+++ b/tests/search/sorter_test.py
@@ -1,0 +1,73 @@
+from tests.unit_test_base import UnitTestBase
+from pyshelf.search.sort_flag import SortFlag
+from pyshelf.search.sort_type import SortType
+import tests.metadata_utils as utils
+from pyshelf.search.sorter import Sorter
+
+
+class SorterTest(UnitTestBase):
+    def setUp(self):
+        super(SorterTest, self).setUp()
+        self.sorter = Sorter()
+
+    def test_sorted_desc_and_asc(self):
+        sort = [
+            {
+                "field": "version",
+                "sort_type": SortType.DESC,
+                "flag_list": [
+                    SortFlag.VERSION
+                ]
+            },
+            {
+                "field": "artifactName",
+                "sort_type": SortType.ASC
+            },
+        ]
+
+        data = [
+            utils.get_meta("zzzz", "/zzzz", "1.19"),
+            utils.get_meta("a", "/a", "1.19"),
+            utils.get_meta("thing", "/thing", "1.2"),
+            utils.get_meta("blah", "/blah", "1.19"),
+        ]
+
+        results = self.sorter.sort(data, sort)
+
+        expected = [
+            utils.get_meta("a", "/a", "1.19"),
+            utils.get_meta("blah", "/blah", "1.19"),
+            utils.get_meta("zzzz", "/zzzz", "1.19"),
+            utils.get_meta("thing", "/thing", "1.2"),
+        ]
+        self.asserts.json_equals(expected, results)
+
+    def test_tilde_sort(self):
+        sort = [
+            {
+                "field": "version",
+                "sort_type": SortType.ASC,
+                "flag_list": [
+                    SortFlag.VERSION
+                ]
+            }
+        ]
+
+        data = [
+            utils.get_meta("a", "/a", "1.19"),
+            utils.get_meta("blah", "/blah", "1.19"),
+            utils.get_meta("thing", "/thing", "1.2"),
+            utils.get_meta("other", "/this/that/other", "1.1"),
+            utils.get_meta("zzzz", "/zzzz", "1.19")
+        ]
+
+        results = self.sorter.sort(data, sort)
+
+        expected = [
+            utils.get_meta("other", "/this/that/other", "1.1"),
+            utils.get_meta("thing", "/thing", "1.2"),
+            utils.get_meta("a", "/a", "1.19"),
+            utils.get_meta("blah", "/blah", "1.19"),
+            utils.get_meta("zzzz", "/zzzz", "1.19")
+        ]
+        self.asserts.json_equals(expected, results)


### PR DESCRIPTION
This is a hotfix and thus going straight to master.