### PR TITLE
Avoid getting successful emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ notifications:
             - andygertjejansen@outlook.com
             - uilwen@gmail.com
             - fidian@rumkin.com
-        on_success: always
-        on_failure: always


### PR DESCRIPTION
This turns notifications down a bit so that only changes and failures are sent to the recipients.  So, you'd get an email when

* the build starts to fail
* the build continues to fail
* the build passed the first time