### PR TITLE
Fixing version sorting issue and add test to expose it.

### DIFF
--- a/pyshelf/search/sorter.py
+++ b/pyshelf/search/sorter.py
@@ -20,15 +20,23 @@ class Sorter(object):
         # of the sort results on a DESC sort and beginning of ASC sort.
         # Used def as opposed to lambda because of my linter complained about assigning a lambda.
         def standard_sort(result):
-            return result.get(criteria["field"], {}).get("value")
+            item = result.get(criteria["field"], {})
+            value = item.get("value")
+
+            return value
 
         # This sort only differs in two ways from the above. Rather then returning the default
         # `None` it returns "0" as this creates the proper sort order. Secondly, it uses
         # distutils.version.LooseVersion to facilitate the version sort.
         def version_sort(result):
-            version = LooseVersion(result.get(criteria["field"], {}).get("value", "0"))
+            value = standard_sort(result)
 
-            return version
+            if value is None:
+                value = "0"
+
+            loose_version = LooseVersion(value)
+
+            return loose_version
 
         # Criteria for sorting is reversed so the order is respected.
         # Basically the method we are using to search must started with the last

--- a/pyshelf/search/sorter.py
+++ b/pyshelf/search/sorter.py
@@ -19,8 +19,16 @@ class Sorter(object):
         # This causes results without the field that is being sorted by to be at the end
         # of the sort results on a DESC sort and beginning of ASC sort.
         # Used def as opposed to lambda because of my linter complained about assigning a lambda.
-        def sort_result(result):
+        def standard_sort(result):
             return result.get(criteria["field"], {}).get("value")
+
+        # This sort only differs in two ways from the above. Rather then returning the default
+        # `None` it returns "0" as this creates the proper sort order. Secondly, it uses
+        # distutils.version.LooseVersion to facilitate the version sort.
+        def version_sort(result):
+            version = LooseVersion(result.get(criteria["field"], {}).get("value", "0"))
+
+            return version
 
         # Criteria for sorting is reversed so the order is respected.
         # Basically the method we are using to search must started with the last
@@ -32,9 +40,11 @@ class Sorter(object):
             if SortType.DESC == criteria["sort_type"]:
                 reverse = True
 
+            sort_func = standard_sort
+
             if criteria.get("flag_list") and SortFlag.VERSION in criteria.get("flag_list"):
-                data.sort(key=lambda k: LooseVersion(sort_result(k)), reverse=reverse)
-            else:
-                data.sort(key=sort_result, reverse=reverse)
+                sort_func = version_sort
+
+            data.sort(key=sort_func, reverse=reverse)
 
         return data

--- a/tests/search/sorter_test.py
+++ b/tests/search/sorter_test.py
@@ -3,6 +3,7 @@ from pyshelf.search.sort_flag import SortFlag
 from pyshelf.search.sort_type import SortType
 import tests.metadata_utils as utils
 from pyshelf.search.sorter import Sorter
+from copy import deepcopy
 
 
 class SorterTest(UnitTestBase):
@@ -71,3 +72,52 @@ class SorterTest(UnitTestBase):
             utils.get_meta("zzzz", "/zzzz", "1.19")
         ]
         self.asserts.json_equals(expected, results)
+
+    def test_version_sort_missing_property(self):
+        sort = [
+            {
+                "field": "buildNumber",
+                "sort_type": SortType.DESC,
+                "flag_list": [
+                    SortFlag.VERSION
+                ]
+            }
+        ]
+
+        data = [
+            {
+                "nothing": {
+                    "name": "nothing",
+                    "value": "stuff",
+                    "immutable": True
+                }
+            },
+            {
+                "buildNumber": {
+                    "name": "buildNumber",
+                    "value": "187",
+                    "immutable": True
+                }
+            },
+            {
+                "buildNumber": {
+                    "name": "buildNumber",
+                    "value": "205",
+                    "immutable": True
+                }
+            }
+        ]
+
+        # Descending sort test with missing property
+        # rather then returning `None` version sorts return
+        # "0" as that acts as `None` does with version sorts.
+        results = self.sorter.sort(data, sort)
+        expected = deepcopy(data)
+        self.asserts.json_equals(expected, results)
+
+        # Ascending sort test making sure both directions with
+        # versions work properly with a missing property.
+        sort[0]["sort_type"] = SortType.ASC
+        asc_results = self.sorter.sort(data, sort)
+        expected.reverse()
+        self.asserts.json_equals(expected, asc_results)


### PR DESCRIPTION
The issue was when None was returned from the sort_results function
during a sort, LooseVersion threw a ValueError. Now we default
version sorts to "0" to ensure they are always sent to the front on
ASC sort and back on DESC.

This is a hot-fix so it is going straight to master.