### PR TITLE
Fixing permissions_validator bug.

### DIFF
--- a/pyshelf/permissions_validator.py
+++ b/pyshelf/permissions_validator.py
@@ -68,10 +68,10 @@ class PermissionsValidator(object):
             if "/_search" in path:
                 allowed = True
             elif method in PermissionsValidator.REQUIRES_WRITE and "/artifact/" in path:
-                write = self.permissions.get("write")
+                write = self.permissions.get("write", [])
                 allowed = self._get_access(write)
             elif method in PermissionsValidator.REQUIRES_READ and "/artifact/" in path:
-                read = self.permissions.get("read")
+                read = self.permissions.get("read", [])
                 allowed = self._get_access(read)
 
         return allowed
@@ -81,7 +81,7 @@ class PermissionsValidator(object):
             Determines if key associated with request has proper access.
 
             Args:
-                permissions(dict): Permissions loaded from _keys directory of requested bucket.
+                permissions(list): Permissions loaded from _keys directory of requested bucket.
 
             Returns:
                 bool: sufficient permissions.
@@ -97,4 +97,5 @@ class PermissionsValidator(object):
         for p in permissions:
             if fnmatch(artifact_path, p) or fnmatch(dir_path, p):
                 return True
+
         return access

--- a/tests/functional_test_base.py
+++ b/tests/functional_test_base.py
@@ -219,12 +219,29 @@ class FunctionalTestBase(TestBase):
         self.search_wrapper.add_metadata(resource_id.search, data)
 
     def create_auth_key(self):
-        self.auth = utils.auth_header()
-        key_name = "_keys/{0}".format(self.auth["Authorization"])
+        # TODO: Revamp the permissions utils stuff. I am not
+        # a fan of how it works.
+        self.auth = self.setup_auth_token(utils.VALID_TOKEN)
+        self.read_only_auth = self.setup_auth_token(utils.READ_ONLY_TOKEN)
+
+    def setup_auth_token(self, token):
+        """
+            Sets up authorization key file in both functional test buckets.
+
+            Args:
+                token: string
+
+            Returns:
+                dict: Authorization header.
+        """
+        key_name = "_keys/{0}".format(token)
+        permissions = utils.get_permissions(token)
         auth_key = Key(self.test_bucket, key_name)
-        auth_key.set_contents_from_string(utils.get_permissions_func_test())
+        auth_key.set_contents_from_string(permissions)
         auth_bucket2 = Key(self.boto_connection.get_bucket("bucket2"), key_name)
-        auth_bucket2.set_contents_from_string(utils.get_permissions_func_test())
+        auth_bucket2.set_contents_from_string(permissions)
+
+        return utils.auth_header(token)
 
     def create_metadata_builder(self):
         return MetadataBuilder()

--- a/tests/permission_utils.py
+++ b/tests/permission_utils.py
@@ -1,4 +1,6 @@
-VALID_KEY = "190a64931e6e49ccb9917c7f32a29d19"
+VALID_TOKEN = "190a64931e6e49ccb9917c7f32a29d19"
+READ_ONLY_TOKEN = "READONLY"
+FULL_TOKEN = "FULLON"
 
 
 def get_permissions_all():
@@ -8,17 +10,15 @@ def get_permissions_all():
         write:
           - '/*'
         read:
-          - '/*'""".format(VALID_KEY)
+          - '/*'""".format(VALID_TOKEN)
 
 
 def get_permissions_readonly():
     return """
         name: 'Andy Gertjejansen'
         token: {0}
-        write:
-          - ''
         read:
-          - '/*'""".format(VALID_KEY)
+          - '/*'""".format(READ_ONLY_TOKEN)
 
 
 def get_permissions_func_test():
@@ -32,8 +32,19 @@ def get_permissions_func_test():
         read:
           - '/'
           - '/dir/dir2/'
-          - '/dir/dir2/dir3/*'""".format(VALID_KEY)
+          - '/dir/dir2/dir3/*'""".format(VALID_TOKEN)
 
 
-def auth_header():
-    return {"Authorization": VALID_KEY}
+def get_permissions(token):
+    if token == VALID_TOKEN:
+        return get_permissions_func_test()
+    elif token == READ_ONLY_TOKEN:
+        return get_permissions_readonly()
+
+    return get_permissions_all()
+
+
+def auth_header(token):
+    return {
+        "Authorization": token
+    }

--- a/tests/routes/metadata_test.py
+++ b/tests/routes/metadata_test.py
@@ -31,6 +31,13 @@ class MetadataTest(FunctionalTestBase):
             .put(data=meta_utils.send_meta(), headers=self.auth)
         self.assert_metadata_matches("/test/artifact/dir/dir2/dir3/nest-test/_meta")
 
+    def test_put_metadata_no_write(self):
+        self.route_tester \
+            .metadata() \
+            .route_params(bucket_name="test", path="dir/dir2/dir3/nest-test") \
+            .expect(401, self.RESPONSE_401) \
+            .put(data=meta_utils.send_meta(), headers=self.read_only_auth)
+
     def test_put_metadata_omit_property_ensure_it_is_deleted(self):
         meta = meta_utils.send_meta()
         del meta["version"]


### PR DESCRIPTION
If the read or write in a token was not there it would cause Shelf
to blowup and return a 500. No clue how this was missed until now.
I defaulted the get to an empty list and added tests